### PR TITLE
Location and Entity Collectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Other ###
+run/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,13 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     kotlin("jvm") version "1.9.23"
     `maven-publish`
     java
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("xyz.jpenilla.run-paper") version "2.3.0"
 }
 
 group = "com.azuyamat.mccollector"
-version = "1.1.0"
+version = "1.2.0"
 
 repositories {
     mavenCentral()
@@ -46,10 +45,15 @@ publishing {
 }
 
 tasks {
-    register("jarTest", ShadowJar::class) {
+    shadowJar {
         archiveClassifier.set("test")
         from(sourceSets["main"].output)
         from(sourceSets["test"].output)
+        from(sourceSets["test"].resources)
         configurations = listOf(project.configurations.getByName("testRuntimeClasspath"))
+    }
+
+    runServer {
+        minecraftVersion("1.20.4")
     }
 }

--- a/src/main/kotlin/com/azuyamat/mccollector/CollectorRegistry.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/CollectorRegistry.kt
@@ -3,6 +3,7 @@ package com.azuyamat.mccollector
 import com.azuyamat.mccollector.CollectorRegistry.init
 import com.azuyamat.mccollector.CollectorRegistry.initialized
 import com.azuyamat.mccollector.collectors.Collector
+import com.azuyamat.mccollector.listeners.*
 import com.azuyamat.mccollector.listeners.ChatListener
 import com.azuyamat.mccollector.listeners.CommandListener
 import com.azuyamat.mccollector.listeners.InventoryListener
@@ -43,7 +44,9 @@ object CollectorRegistry {
                 QuitListener(),
                 ChatListener(),
                 CommandListener(),
-                InventoryListener()
+                InventoryListener(),
+                LocationListener(),
+                EntityListener()
             ).forEach {
                 plugin.server.pluginManager.registerEvents(it, plugin)
             }

--- a/src/main/kotlin/com/azuyamat/mccollector/Restriction.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/Restriction.kt
@@ -13,4 +13,6 @@ sealed class Restriction(val action: (Player) -> Unit = {}) {
     class Chat(action: (Player) -> Unit = {}) : Restriction(action)
     class Command(action: (Player) -> Unit = {}) : Restriction(action)
     class InventoryManipulation(action: (Player) -> Unit = {}) : Restriction(action)
+    class Location(action: (Player) -> Unit = {}) : Restriction(action)
+    class Entity(action: (Player) -> Unit = {}) : Restriction(action)
 }

--- a/src/main/kotlin/com/azuyamat/mccollector/builders/EntityCollectorBuilder.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/builders/EntityCollectorBuilder.kt
@@ -1,0 +1,28 @@
+package com.azuyamat.mccollector.builders
+
+import com.azuyamat.mccollector.Restriction
+import com.azuyamat.mccollector.collectors.Collector
+import com.azuyamat.mccollector.collectors.EntityCollector
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+
+/**
+ * A builder for creating an [EntityCollectorBuilder].
+ *
+ * @param prompt The prompt to display to the player.
+ * @constructor Creates an EntityCollectorBuilder.
+ * @since 1.1.0
+ */
+class EntityCollectorBuilder(
+    prompt: () -> Unit,
+) : CollectorBuilder<Entity>(prompt) {
+    init {
+        meta.restrictions.addAll(listOf(
+            Restriction.Entity()
+        ))
+    }
+
+    override fun build(player: Player): Collector<Entity> {
+        return EntityCollector(player, meta)
+    }
+}

--- a/src/main/kotlin/com/azuyamat/mccollector/builders/LocationCollectorBuilder.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/builders/LocationCollectorBuilder.kt
@@ -1,0 +1,28 @@
+package com.azuyamat.mccollector.builders
+
+import com.azuyamat.mccollector.Restriction
+import com.azuyamat.mccollector.collectors.Collector
+import com.azuyamat.mccollector.collectors.LocationCollector
+import org.bukkit.Location
+import org.bukkit.entity.Player
+
+/**
+ * A builder for creating an [LocationCollectorBuilder].
+ *
+ * @param prompt The prompt to display to the player.
+ * @constructor Creates an LocationCollectorBuilder.
+ * @since 1.1.0
+ */
+class LocationCollectorBuilder(
+    prompt: () -> Unit,
+) : CollectorBuilder<Location>(prompt) {
+    init {
+        meta.restrictions.addAll(listOf(
+            Restriction.Location()
+        ))
+    }
+
+    override fun build(player: Player): Collector<Location> {
+        return LocationCollector(player, meta)
+    }
+}

--- a/src/main/kotlin/com/azuyamat/mccollector/collectors/EntityCollector.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/collectors/EntityCollector.kt
@@ -1,0 +1,23 @@
+package com.azuyamat.mccollector.collectors
+
+import com.azuyamat.mccollector.meta.CollectorMeta
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+
+/**
+ * A collector that collects entity clicks.
+ *
+ * @param player the player to collect from
+ * @param meta the meta of the collector
+ * @see Collector
+ * @since 1.2.0
+ */
+class EntityCollector internal constructor(
+    override val player: Player,
+    override val meta: CollectorMeta<Entity>
+) : Collector<Entity>(player, meta), Verifiable<Entity> {
+    override fun verifyValue(value: Entity): Verifiable.ValidationResult {
+        resetTimeout()
+        return meta.verifyValue(value)
+    }
+}

--- a/src/main/kotlin/com/azuyamat/mccollector/collectors/LocationCollector.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/collectors/LocationCollector.kt
@@ -1,0 +1,23 @@
+package com.azuyamat.mccollector.collectors
+
+import com.azuyamat.mccollector.meta.CollectorMeta
+import org.bukkit.Location
+import org.bukkit.entity.Player
+
+/**
+ * A collector that collects location clicks.
+ *
+ * @param player the player to collect from
+ * @param meta the meta of the collector
+ * @see Collector
+ * @since 1.2.0
+ */
+class LocationCollector internal constructor(
+    override val player: Player,
+    override val meta: CollectorMeta<Location>
+) : Collector<Location>(player, meta), Verifiable<Location> {
+    override fun verifyValue(value: Location): Verifiable.ValidationResult {
+        resetTimeout()
+        return meta.verifyValue(value)
+    }
+}

--- a/src/main/kotlin/com/azuyamat/mccollector/listeners/ChatListener.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/listeners/ChatListener.kt
@@ -21,6 +21,7 @@ internal class ChatListener : Listener {
 
         val content = (event.message() as TextComponent).content()
         if (content.equals("cancel", true)) {
+            event.isCancelled = true
             collector.onCancel()
             return
         }

--- a/src/main/kotlin/com/azuyamat/mccollector/listeners/EntityListener.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/listeners/EntityListener.kt
@@ -1,0 +1,32 @@
+package com.azuyamat.mccollector.listeners
+
+import com.azuyamat.mccollector.CollectorRegistry
+import com.azuyamat.mccollector.Restriction
+import com.azuyamat.mccollector.collectors.EntityCollector
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEntityEvent
+
+class EntityListener : Listener {
+    @EventHandler
+    fun onClick(event: PlayerInteractEntityEvent) {
+        if (!CollectorRegistry.initialized) return
+
+        val player = event.player
+        val collector = CollectorRegistry.getCollector(player.uniqueId) ?: return
+        collector.getRestriction(Restriction.Entity::class)?.let {
+            event.isCancelled = true
+            it.action(player)
+        }
+
+        if (collector !is EntityCollector) return
+        val entity = event.rightClicked
+
+        val result = collector.verifyValue(entity)
+        if (result.isValid) {
+            collector.onCollect(entity)
+        } else {
+            collector.onInvalid(result, entity)
+        }
+    }
+}

--- a/src/main/kotlin/com/azuyamat/mccollector/listeners/LocationListener.kt
+++ b/src/main/kotlin/com/azuyamat/mccollector/listeners/LocationListener.kt
@@ -1,0 +1,32 @@
+package com.azuyamat.mccollector.listeners
+
+import com.azuyamat.mccollector.CollectorRegistry
+import com.azuyamat.mccollector.Restriction
+import com.azuyamat.mccollector.collectors.LocationCollector
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEvent
+
+class LocationListener : Listener {
+    @EventHandler
+    fun onClick(event: PlayerInteractEvent) {
+        if (!CollectorRegistry.initialized) return
+
+        val player = event.player
+        val collector = CollectorRegistry.getCollector(player.uniqueId) ?: return
+        collector.getRestriction(Restriction.Location::class)?.let {
+            event.isCancelled = true
+            it.action(player)
+        }
+
+        if (collector !is LocationCollector) return
+        val location = event.clickedBlock?.location ?: return
+
+        val result = collector.verifyValue(location)
+        if (result.isValid) {
+            collector.onCollect(location)
+        } else {
+            collector.onInvalid(result, location)
+        }
+    }
+}

--- a/src/test/kotlin/commands/TestCommand.kt
+++ b/src/test/kotlin/commands/TestCommand.kt
@@ -5,7 +5,10 @@ import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.Default
 import co.aikar.commands.annotation.Subcommand
 import com.azuyamat.mccollector.builders.ChatCollectorBuilder
+import com.azuyamat.mccollector.builders.EntityCollectorBuilder
 import com.azuyamat.mccollector.builders.InventoryCollectorBuilder
+import com.azuyamat.mccollector.builders.LocationCollectorBuilder
+import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 
 @CommandAlias("test")
@@ -28,6 +31,30 @@ class TestCommand : BaseCommand() {
             .onCollect {
                 player.sendMessage("Collected ${it.type}")
             }.build(player)
+
+        collector.register()
+    }
+
+    @Subcommand("location")
+    fun onLocation(player: Player) {
+        val collector = LocationCollectorBuilder {
+            player.sendMessage("Click a location")
+        }.onCollect {
+            player.sendMessage("Collected ${it.blockX}, ${it.blockY}, ${it.blockZ}")
+        }.build(player)
+
+        collector.register()
+    }
+
+    @Subcommand("entity")
+    fun onEntity(player: Player) {
+        val collector = EntityCollectorBuilder {
+            player.sendMessage("Click an entity")
+        }.onCollect {
+            player.sendMessage("Collected ${it.type}")
+        }.onCancel {
+            player.sendMessage("Cancelled")
+        }.build(player)
 
         collector.register()
     }

--- a/src/test/resources/plugin.yml
+++ b/src/test/resources/plugin.yml
@@ -1,3 +1,3 @@
-  name: MCCollectorTest
-  main: MCCollectorTest
-  version: 1.0.0
+name: MCCollectorTest
+main: MCCollectorTest
+version: 1.0.0


### PR DESCRIPTION
This PR adds two new collectors and some tools for testing.

Location Collector allows you to collect the location of the player's next clicked block.
Entity Collector allows you to collect the player's next clicked entity.

It also adds the runServer gradle task that starts up a Minecraft server with the plugin in the test directory to be used for testing.